### PR TITLE
Fix three data race bugs in hotel library

### DIFF
--- a/hotel/client_test.go
+++ b/hotel/client_test.go
@@ -1,0 +1,328 @@
+package hotel
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestClientContext verifies the Context() accessor.
+func TestClientContext(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("client-context-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	client, err := room.NewClient(&struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	ctx := client.Context()
+	if ctx == nil {
+		t.Fatal("Expected non-nil context")
+	}
+
+	// Context should not be done yet
+	select {
+	case <-ctx.Done():
+		t.Error("Context should not be done")
+	default:
+		// Good
+	}
+
+	// Close client and verify context is done
+	client.Close()
+
+	select {
+	case <-ctx.Done():
+		// Good
+	case <-time.After(time.Second):
+		t.Error("Context should be done after Close")
+	}
+}
+
+// TestClientMetadata verifies the Metadata() accessor.
+func TestClientMetadata(t *testing.T) {
+	type Meta struct {
+		Name string
+		ID   int
+	}
+
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, Meta, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("client-metadata-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	meta := &Meta{Name: "TestUser", ID: 42}
+	client, err := room.NewClient(meta)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	gotMeta := client.Metadata()
+	if gotMeta != meta {
+		t.Error("Metadata should return the same pointer")
+	}
+	if gotMeta.Name != "TestUser" {
+		t.Errorf("Expected Name 'TestUser', got %q", gotMeta.Name)
+	}
+	if gotMeta.ID != 42 {
+		t.Errorf("Expected ID 42, got %d", gotMeta.ID)
+	}
+}
+
+// TestClientSendToClosedClient verifies send returns error for closed client.
+func TestClientSendToClosedClient(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("send-closed-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	client, err := room.NewClient(&struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Close client first
+	client.Close()
+
+	// send() is internal, so we test via SendToClient which will remove client
+	// But since client is already closed, the context check in send() should trigger
+	// We need to keep client in room to test send directly
+	// Create new client for this test
+	client2, err := room.NewClient(&struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client2: %v", err)
+	}
+
+	// Start receiver to keep client active
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range client2.Receive() {
+		}
+	}()
+
+	// Close client2 and immediately try to send
+	client2.Close()
+	time.Sleep(10 * time.Millisecond) // Let close propagate
+
+	// SendToClient should fail (client removed or send fails)
+	err = room.SendToClient(client2, "test")
+	if err == nil {
+		t.Log("SendToClient succeeded (client may not be removed yet)")
+	}
+
+	wg.Wait()
+}
+
+// TestClientBufferFull verifies that full buffer closes client.
+func TestClientBufferFull(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			// Drain events
+			for {
+				select {
+				case <-room.Events():
+				case <-ctx.Done():
+					return
+				}
+			}
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("buffer-full-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	// Create client with minimal buffer
+	client, err := room.NewClientWithBuffer(1, &struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Don't read from client - let buffer fill up
+	// The send() method should return error and close client when buffer is full
+
+	// Keep sending until we get an error or client is removed
+	maxAttempts := 100
+	var sendErr error
+	for i := 0; i < maxAttempts; i++ {
+		sendErr = room.SendToClient(client, "message")
+		if sendErr != nil {
+			break
+		}
+	}
+
+	// Should have gotten an error (client disconnected or not found)
+	if sendErr == nil {
+		t.Log("No error after many sends - buffer may be larger than expected")
+	}
+
+	// Verify client context is done
+	select {
+	case <-client.Context().Done():
+		// Good - client was closed
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Client should be closed after buffer overflow")
+	}
+}
+
+// TestClientReceiveClosesOnClientClose verifies Receive() channel closes when client closes.
+func TestClientReceiveClosesOnClientClose(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("receive-close-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	client, err := room.NewClient(&struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	receiveClosed := make(chan struct{})
+	go func() {
+		for range client.Receive() {
+			// Drain
+		}
+		close(receiveClosed)
+	}()
+
+	// Close client
+	client.Close()
+
+	// Receive should close
+	select {
+	case <-receiveClosed:
+		// Good
+	case <-time.After(time.Second):
+		t.Error("Receive channel should close when client closes")
+	}
+}
+
+// TestClientCloseIdempotent verifies Close() can be called multiple times safely.
+func TestClientCloseIdempotent(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("close-idempotent-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	client, err := room.NewClient(&struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Close multiple times - should not panic
+	for i := 0; i < 10; i++ {
+		client.Close()
+	}
+
+	// Context should be done
+	select {
+	case <-client.Context().Done():
+		// Good
+	default:
+		t.Error("Context should be done after Close")
+	}
+}
+
+// TestClientConcurrentClose verifies concurrent Close() calls are safe.
+func TestClientConcurrentClose(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("concurrent-close-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	client, err := room.NewClient(&struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Close from multiple goroutines concurrently
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			client.Close()
+		}()
+	}
+
+	wg.Wait()
+
+	// Should have completed without panic
+	select {
+	case <-client.Context().Done():
+		// Good
+	default:
+		t.Error("Context should be done")
+	}
+}

--- a/hotel/event_test.go
+++ b/hotel/event_test.go
@@ -1,0 +1,40 @@
+package hotel
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEventTypeString verifies all EventType values have string representations.
+func TestEventTypeString(t *testing.T) {
+	tests := []struct {
+		eventType EventType
+		expected  string
+	}{
+		{EventJoin, "EventJoin"},
+		{EventLeave, "EventLeave"},
+		{EventCustom, "EventCustom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got := tt.eventType.String()
+			if got != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+// TestEventTypeStringUnknown verifies unknown EventType values are handled.
+func TestEventTypeStringUnknown(t *testing.T) {
+	unknown := EventType(999)
+	got := unknown.String()
+
+	if !strings.Contains(got, "999") {
+		t.Errorf("Expected string to contain '999', got %q", got)
+	}
+	if !strings.HasPrefix(got, "<!EventType") {
+		t.Errorf("Expected string to start with '<!EventType', got %q", got)
+	}
+}

--- a/hotel/hotel.go
+++ b/hotel/hotel.go
@@ -74,7 +74,11 @@ func (h *Hotel[RoomMetadata, ClientMetadata, DataType]) GetOrCreateRoom(id strin
 				go func() {
 					<-room.ctx.Done()
 					h.mu.Lock()
-					delete(h.rooms, room.id)
+					// Only delete if this room is still in the map (another
+					// goroutine may have already replaced it with a new room).
+					if h.rooms[room.id] == room {
+						delete(h.rooms, room.id)
+					}
 					h.mu.Unlock()
 				}()
 			}

--- a/hotel/messages_test.go
+++ b/hotel/messages_test.go
@@ -1,0 +1,134 @@
+package hotel
+
+import (
+	"testing"
+)
+
+// TestMessage is a simple message type for testing
+type TestMessage struct {
+	Content string
+}
+
+func (m *TestMessage) Type() string {
+	return "test"
+}
+
+// AnotherMessage is another message type for testing
+type AnotherMessage struct {
+	Value int
+}
+
+func (m *AnotherMessage) Type() string {
+	return "another"
+}
+
+// TestMessageRegistryRegister verifies that messages can be registered.
+func TestMessageRegistryRegister(t *testing.T) {
+	registry := make(MessageRegistry[Message])
+
+	registry.Register(&TestMessage{})
+
+	if len(registry) != 1 {
+		t.Errorf("Expected 1 registered type, got %d", len(registry))
+	}
+
+	if _, ok := registry["test"]; !ok {
+		t.Error("Expected 'test' type to be registered")
+	}
+}
+
+// TestMessageRegistryRegisterMultiple verifies multiple messages can be registered.
+func TestMessageRegistryRegisterMultiple(t *testing.T) {
+	registry := make(MessageRegistry[Message])
+
+	registry.Register(&TestMessage{}, &AnotherMessage{})
+
+	if len(registry) != 2 {
+		t.Errorf("Expected 2 registered types, got %d", len(registry))
+	}
+
+	if _, ok := registry["test"]; !ok {
+		t.Error("Expected 'test' type to be registered")
+	}
+	if _, ok := registry["another"]; !ok {
+		t.Error("Expected 'another' type to be registered")
+	}
+}
+
+// TestMessageRegistryRegisterDuplicate verifies that duplicate registration panics.
+func TestMessageRegistryRegisterDuplicate(t *testing.T) {
+	registry := make(MessageRegistry[Message])
+
+	registry.Register(&TestMessage{})
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic on duplicate registration")
+		}
+	}()
+
+	// This should panic
+	registry.Register(&TestMessage{})
+}
+
+// TestMessageRegistryCreate verifies that registered messages can be created.
+func TestMessageRegistryCreate(t *testing.T) {
+	registry := make(MessageRegistry[Message])
+	registry.Register(&TestMessage{})
+
+	msg, err := registry.Create("test")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if msg == nil {
+		t.Fatal("Expected non-nil message")
+	}
+
+	if msg.Type() != "test" {
+		t.Errorf("Expected type 'test', got %q", msg.Type())
+	}
+
+	// Verify it's actually a *TestMessage
+	testMsg, ok := msg.(*TestMessage)
+	if !ok {
+		t.Error("Expected message to be *TestMessage")
+	}
+
+	// Verify it's a new instance (not the same as registered)
+	if testMsg.Content != "" {
+		t.Error("Expected empty Content for new instance")
+	}
+}
+
+// TestMessageRegistryCreateUnknown verifies that creating unknown types returns error.
+func TestMessageRegistryCreateUnknown(t *testing.T) {
+	registry := make(MessageRegistry[Message])
+
+	_, err := registry.Create("unknown")
+	if err == nil {
+		t.Error("Expected error for unknown message type")
+	}
+}
+
+// TestMessageRegistryCreateMultipleTypes verifies creating different types works.
+func TestMessageRegistryCreateMultipleTypes(t *testing.T) {
+	registry := make(MessageRegistry[Message])
+	registry.Register(&TestMessage{}, &AnotherMessage{})
+
+	msg1, err := registry.Create("test")
+	if err != nil {
+		t.Fatalf("Create 'test' failed: %v", err)
+	}
+	if _, ok := msg1.(*TestMessage); !ok {
+		t.Error("Expected *TestMessage")
+	}
+
+	msg2, err := registry.Create("another")
+	if err != nil {
+		t.Fatalf("Create 'another' failed: %v", err)
+	}
+	if _, ok := msg2.(*AnotherMessage); !ok {
+		t.Error("Expected *AnotherMessage")
+	}
+}

--- a/hotel/race_test.go
+++ b/hotel/race_test.go
@@ -1,0 +1,336 @@
+package hotel
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestMetadataDataRace verifies that Metadata() is safe to call concurrently
+// with room initialization. This test should be run with -race.
+func TestMetadataDataRace(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		initStarted := make(chan struct{})
+		var initStartedOnce sync.Once
+
+		hotel := New(
+			func(ctx context.Context, id string) (*string, error) {
+				initStartedOnce.Do(func() {
+					close(initStarted)
+				})
+				// Simulate slow initialization
+				time.Sleep(5 * time.Millisecond)
+				metadata := "room-metadata"
+				return &metadata, nil
+			},
+			func(ctx context.Context, room *Room[string, string, string]) {
+				<-ctx.Done()
+			},
+		)
+
+		var wg sync.WaitGroup
+		roomID := fmt.Sprintf("test-room-%d", i)
+
+		// First goroutine: Creates the room
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			room, err := hotel.GetOrCreateRoom(roomID)
+			if err != nil {
+				t.Errorf("Failed to create room: %v", err)
+				return
+			}
+			// Access metadata after init completes
+			_ = room.Metadata()
+			room.Close()
+		}()
+
+		// Wait for init to start
+		<-initStarted
+
+		// Second goroutine: Tries to get the same room and access metadata
+		// while initialization may still be running
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			room, err := hotel.GetOrCreateRoom(roomID)
+			if err != nil {
+				// Room may have been closed, that's OK
+				return
+			}
+			// This should be safe even if called during initialization
+			_ = room.Metadata()
+		}()
+
+		wg.Wait()
+	}
+}
+
+// TestGetOrCreateRoomDoesNotReturnClosedRoom verifies that GetOrCreateRoom
+// never returns a closed room. Previously, there was a race condition where
+// a closed room could be returned before the cleanup goroutine removed it
+// from the map.
+func TestGetOrCreateRoomDoesNotReturnClosedRoom(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	roomID := "test-closed-room"
+
+	// Run multiple iterations to increase chance of hitting the race
+	for i := 0; i < 100; i++ {
+		// Create a room
+		room1, err := hotel.GetOrCreateRoom(roomID)
+		if err != nil {
+			t.Fatalf("Failed to create room: %v", err)
+		}
+
+		// Close the room
+		room1.Close()
+
+		// Immediately try to get the room - this should either:
+		// 1. Create a new room (if cleanup already ran)
+		// 2. Wait for the old room to be cleaned up and create a new one
+		// It should NEVER return the closed room
+		room2, err := hotel.GetOrCreateRoom(roomID)
+		if err != nil {
+			t.Fatalf("Failed to get room after close: %v", err)
+		}
+
+		// Verify the room is usable by trying to create a client
+		client, err := room2.NewClient(&struct{}{})
+		if err != nil {
+			t.Errorf("Iteration %d: GetOrCreateRoom returned a closed room: %v", i, err)
+			continue
+		}
+
+		// Clean up
+		room2.RemoveClient(client)
+		room2.Close()
+	}
+}
+
+// TestGetOrCreateRoomConcurrentClose verifies that concurrent calls to
+// GetOrCreateRoom handle room closure correctly.
+func TestGetOrCreateRoomConcurrentClose(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	roomID := "test-concurrent-close"
+
+	for iteration := 0; iteration < 20; iteration++ {
+		// Create a room
+		room1, err := hotel.GetOrCreateRoom(roomID)
+		if err != nil {
+			t.Fatalf("Failed to create room: %v", err)
+		}
+
+		// Close it
+		room1.Close()
+
+		// Have multiple goroutines try to get/create the room immediately after close
+		var wg sync.WaitGroup
+		errors := make(chan error, 10)
+
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func(id int) {
+				defer wg.Done()
+
+				room, err := hotel.GetOrCreateRoom(roomID)
+				if err != nil {
+					errors <- fmt.Errorf("goroutine %d: failed to get room: %v", id, err)
+					return
+				}
+
+				// Verify the room is usable
+				client, err := room.NewClient(&struct{}{})
+				if err != nil {
+					errors <- fmt.Errorf("goroutine %d: got closed room: %v", id, err)
+					return
+				}
+				room.RemoveClient(client)
+			}(i)
+		}
+
+		wg.Wait()
+		close(errors)
+
+		for err := range errors {
+			t.Error(err)
+		}
+
+		// Clean up for next iteration
+		room, _ := hotel.GetOrCreateRoom(roomID)
+		room.Close()
+	}
+}
+
+// TestClientMessageDeliveryOnClose verifies that messages queued before
+// client close are delivered to the receiver.
+func TestClientMessageDeliveryOnClose(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			for {
+				select {
+				case <-room.Events():
+				case <-ctx.Done():
+					return
+				}
+			}
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("test-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	// Use a small buffer to make the test faster
+	client, err := room.NewClientWithBuffer(5, &struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	received := make([]string, 0)
+	var mu sync.Mutex
+
+	// Start receiver that processes messages slowly
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for msg := range client.Receive() {
+			mu.Lock()
+			received = append(received, msg)
+			mu.Unlock()
+		}
+	}()
+
+	// Send messages
+	sentCount := 5
+	for i := 0; i < sentCount; i++ {
+		msg := fmt.Sprintf("Message %d", i)
+		err := room.SendToClient(client, msg)
+		if err != nil {
+			t.Logf("Failed to send message %d: %v", i, err)
+		}
+	}
+
+	// Give receiver time to start processing the first message
+	time.Sleep(10 * time.Millisecond)
+
+	// Close the client
+	client.Close()
+
+	// Wait for receiver to finish
+	wg.Wait()
+
+	mu.Lock()
+	receivedCount := len(received)
+	mu.Unlock()
+
+	// We should receive at least some messages. The exact count depends on timing,
+	// but with the drain fix, we should get more than we did before.
+	t.Logf("Sent: %d messages, Received: %d messages", sentCount, receivedCount)
+
+	// With the drain fix, we should receive all messages that were successfully
+	// queued. Since we send 5 messages and give time for processing to start,
+	// we should receive all 5.
+	if receivedCount < sentCount {
+		t.Errorf("Message loss detected: sent %d messages but only received %d (lost %d)",
+			sentCount, receivedCount, sentCount-receivedCount)
+	}
+}
+
+// TestClientBufferDrain verifies that all buffered messages are delivered
+// when a client is closed, even if the receiver is ready.
+func TestClientBufferDrain(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			for {
+				select {
+				case <-room.Events():
+				case <-ctx.Done():
+					return
+				}
+			}
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("test-drain")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	client, err := room.NewClientWithBuffer(10, &struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Send messages without starting receiver yet
+	sentCount := 5
+	for i := 0; i < sentCount; i++ {
+		msg := fmt.Sprintf("Message %d", i)
+		err := room.SendToClient(client, msg)
+		if err != nil {
+			t.Fatalf("Failed to send message %d: %v", i, err)
+		}
+	}
+
+	// Now start receiver and close client almost simultaneously
+	var wg sync.WaitGroup
+	received := make([]string, 0)
+	var mu sync.Mutex
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for msg := range client.Receive() {
+			mu.Lock()
+			received = append(received, msg)
+			mu.Unlock()
+		}
+	}()
+
+	// Small delay to let receiver start
+	time.Sleep(time.Millisecond)
+
+	// Close the client
+	client.Close()
+
+	wg.Wait()
+
+	mu.Lock()
+	receivedCount := len(received)
+	mu.Unlock()
+
+	t.Logf("Sent: %d messages, Received: %d messages", sentCount, receivedCount)
+
+	// With the drain fix, even though we close immediately after starting
+	// the receiver, we should receive all messages because they get drained
+	if receivedCount != sentCount {
+		t.Errorf("Not all messages were delivered: sent %d, received %d", sentCount, receivedCount)
+	}
+}

--- a/hotel/race_test.go
+++ b/hotel/race_test.go
@@ -493,7 +493,7 @@ func TestRoomInitPanicRecovery(t *testing.T) {
 }
 
 // TestGetOrCreateRoomRetryLimit verifies that GetOrCreateRoom fails after
-// maxRoomRetries when rooms keep closing immediately.
+// maxRoomAttempts when rooms keep closing immediately.
 func TestGetOrCreateRoomRetryLimit(t *testing.T) {
 	// Track how many times init was called to verify retries are happening
 	initCount := 0
@@ -519,8 +519,7 @@ func TestGetOrCreateRoomRetryLimit(t *testing.T) {
 	finalCount := initCount
 	mu.Unlock()
 
-	// The room init should have been called at least maxRoomRetries times
-	// (3 retries + possibly the initial attempt depending on timing)
+	// The room init should have been called up to maxRoomAttempts times
 	t.Logf("Init was called %d times", finalCount)
 
 	if err == nil {

--- a/hotel/room.go
+++ b/hotel/room.go
@@ -73,7 +73,9 @@ func newRoom[RoomMetadata, ClientMetadata, DataType any](id string, init RoomIni
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		room.mu.Lock()
 		room.metadata = metadata
+		room.mu.Unlock()
 
 		go func() {
 			defer func() {
@@ -105,6 +107,8 @@ func (r *Room[RoomMetadata, ClientMetadata, DataType]) Events() <-chan Event[Cli
 
 // Metadata returns the room's metadata.
 func (r *Room[RoomMetadata, ClientMetadata, DataType]) Metadata() *RoomMetadata {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.metadata
 }
 

--- a/hotel/room_test.go
+++ b/hotel/room_test.go
@@ -1,0 +1,545 @@
+package hotel
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestBroadcast verifies that Broadcast sends data to all clients.
+func TestBroadcast(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("broadcast-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	// Create multiple clients
+	numClients := 5
+	clients := make([]*Client[struct{}, string], numClients)
+	for i := 0; i < numClients; i++ {
+		client, err := room.NewClient(&struct{}{})
+		if err != nil {
+			t.Fatalf("Failed to create client %d: %v", i, err)
+		}
+		clients[i] = client
+	}
+
+	// Start receivers for all clients
+	var wg sync.WaitGroup
+	received := make([]int, numClients)
+	for i, client := range clients {
+		wg.Add(1)
+		go func(idx int, c *Client[struct{}, string]) {
+			defer wg.Done()
+			for range c.Receive() {
+				received[idx]++
+			}
+		}(i, client)
+	}
+
+	// Broadcast a message
+	room.Broadcast("hello everyone")
+
+	// Give time for messages to be received
+	time.Sleep(50 * time.Millisecond)
+
+	// Close all clients to end receivers
+	for _, client := range clients {
+		client.Close()
+	}
+	wg.Wait()
+
+	// Verify all clients received the message
+	for i, count := range received {
+		if count != 1 {
+			t.Errorf("Client %d received %d messages, expected 1", i, count)
+		}
+	}
+}
+
+// TestBroadcastRemovesFailedClients verifies that Broadcast removes clients that fail to receive.
+func TestBroadcastRemovesFailedClients(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			// Drain events
+			for {
+				select {
+				case <-room.Events():
+				case <-ctx.Done():
+					return
+				}
+			}
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("broadcast-fail-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	// Create a client with small buffer
+	client, err := room.NewClientWithBuffer(1, &struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Don't read from client - let buffer fill up
+	// Broadcast multiple times to fill buffer and trigger removal
+	for i := 0; i < 10; i++ {
+		room.Broadcast("message")
+	}
+
+	// Give time for removal to process
+	time.Sleep(50 * time.Millisecond)
+
+	// Client should have been removed
+	clients := room.Clients()
+	for _, c := range clients {
+		if c == client {
+			t.Error("Failed client should have been removed from room")
+		}
+	}
+}
+
+// TestBroadcastExcept verifies that BroadcastExcept sends to all clients except one.
+func TestBroadcastExcept(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("broadcast-except-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	// Create multiple clients
+	numClients := 5
+	clients := make([]*Client[struct{}, string], numClients)
+	for i := 0; i < numClients; i++ {
+		client, err := room.NewClient(&struct{}{})
+		if err != nil {
+			t.Fatalf("Failed to create client %d: %v", i, err)
+		}
+		clients[i] = client
+	}
+
+	// Start receivers for all clients
+	var wg sync.WaitGroup
+	received := make([]int, numClients)
+	for i, client := range clients {
+		wg.Add(1)
+		go func(idx int, c *Client[struct{}, string]) {
+			defer wg.Done()
+			for range c.Receive() {
+				received[idx]++
+			}
+		}(i, client)
+	}
+
+	// Broadcast to all except client 2
+	excludeIdx := 2
+	room.BroadcastExcept(clients[excludeIdx], "hello others")
+
+	// Give time for messages to be received
+	time.Sleep(50 * time.Millisecond)
+
+	// Close all clients to end receivers
+	for _, client := range clients {
+		client.Close()
+	}
+	wg.Wait()
+
+	// Verify all clients except excluded one received the message
+	for i, count := range received {
+		if i == excludeIdx {
+			if count != 0 {
+				t.Errorf("Excluded client %d received %d messages, expected 0", i, count)
+			}
+		} else {
+			if count != 1 {
+				t.Errorf("Client %d received %d messages, expected 1", i, count)
+			}
+		}
+	}
+}
+
+// TestHandleClientData verifies that HandleClientData emits custom events.
+func TestHandleClientData(t *testing.T) {
+	eventReceived := make(chan Event[struct{}, string], 10)
+
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			for {
+				select {
+				case event := <-room.Events():
+					if event.Type == EventCustom {
+						eventReceived <- event
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("handle-data-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	client, err := room.NewClient(&struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Handle client data
+	testData := "test message from client"
+	err = room.HandleClientData(client, testData)
+	if err != nil {
+		t.Fatalf("HandleClientData failed: %v", err)
+	}
+
+	// Wait for event
+	select {
+	case event := <-eventReceived:
+		if event.Data != testData {
+			t.Errorf("Expected data %q, got %q", testData, event.Data)
+		}
+		if event.Client != client {
+			t.Error("Event client doesn't match")
+		}
+	case <-time.After(time.Second):
+		t.Error("Timeout waiting for custom event")
+	}
+}
+
+// TestHandleClientDataUnknownClient verifies HandleClientData returns error for unknown client.
+func TestHandleClientDataUnknownClient(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("handle-data-unknown")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	// Create a client and remove it
+	client, err := room.NewClient(&struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	room.RemoveClient(client)
+
+	// Try to handle data for removed client
+	err = room.HandleClientData(client, "data")
+	if err == nil {
+		t.Error("Expected error for unknown client")
+	}
+}
+
+// TestFindClient verifies FindClient returns matching clients.
+func TestFindClient(t *testing.T) {
+	type ClientMeta struct {
+		Name string
+		Age  int
+	}
+
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, ClientMeta, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("find-client-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	// Create clients with different metadata
+	alice, _ := room.NewClient(&ClientMeta{Name: "Alice", Age: 30})
+	bob, _ := room.NewClient(&ClientMeta{Name: "Bob", Age: 25})
+	charlie, _ := room.NewClient(&ClientMeta{Name: "Charlie", Age: 35})
+
+	// Find Alice by name
+	found := room.FindClient(func(m *ClientMeta) bool {
+		return m.Name == "Alice"
+	})
+	if found != alice {
+		t.Error("Failed to find Alice")
+	}
+
+	// Find by age
+	found = room.FindClient(func(m *ClientMeta) bool {
+		return m.Age > 30
+	})
+	if found != charlie {
+		t.Error("Failed to find client with age > 30")
+	}
+
+	// Find non-existent
+	found = room.FindClient(func(m *ClientMeta) bool {
+		return m.Name == "David"
+	})
+	if found != nil {
+		t.Error("Expected nil for non-existent client")
+	}
+
+	_ = bob // Use bob to avoid unused variable warning
+}
+
+// TestRoomID verifies the ID() accessor.
+func TestRoomID(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	roomID := "test-room-id-123"
+	room, err := hotel.GetOrCreateRoom(roomID)
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	if room.ID() != roomID {
+		t.Errorf("Expected room ID %q, got %q", roomID, room.ID())
+	}
+}
+
+// TestRoomInitError verifies that init errors are properly propagated.
+func TestRoomInitError(t *testing.T) {
+	expectedErr := errors.New("init failed")
+
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return nil, expectedErr
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	_, err := hotel.GetOrCreateRoom("init-error-room")
+	if err == nil {
+		t.Fatal("Expected error from room init")
+	}
+	if err != expectedErr {
+		t.Errorf("Expected error %v, got %v", expectedErr, err)
+	}
+
+	// Try again - should get same error (room should have been cleaned up)
+	_, err = hotel.GetOrCreateRoom("init-error-room")
+	if err == nil {
+		t.Fatal("Expected error on second attempt")
+	}
+}
+
+// TestRemoveClientNotFound verifies RemoveClient returns error for unknown client.
+func TestRemoveClientNotFound(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("remove-not-found")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	// Create and remove a client
+	client, _ := room.NewClient(&struct{}{})
+	room.RemoveClient(client)
+
+	// Try to remove again
+	err = room.RemoveClient(client)
+	if err == nil {
+		t.Error("Expected error when removing non-existent client")
+	}
+}
+
+// TestSendToClientNotFound verifies SendToClient returns error for unknown client.
+func TestSendToClientNotFound(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("send-not-found")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	// Create and remove a client
+	client, _ := room.NewClient(&struct{}{})
+	room.RemoveClient(client)
+
+	// Try to send to removed client
+	err = room.SendToClient(client, "data")
+	if err == nil {
+		t.Error("Expected error when sending to non-existent client")
+	}
+}
+
+// TestSendToClientRemovesOnError verifies SendToClient removes client on send error.
+func TestSendToClientRemovesOnError(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			// Drain events
+			for {
+				select {
+				case <-room.Events():
+				case <-ctx.Done():
+					return
+				}
+			}
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("send-removes-room")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	// Create client with tiny buffer
+	client, err := room.NewClientWithBuffer(1, &struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Don't read from client, fill buffer, then send more
+	for i := 0; i < 10; i++ {
+		room.SendToClient(client, "msg")
+	}
+
+	// Give time for removal
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify client was removed
+	clients := room.Clients()
+	for _, c := range clients {
+		if c == client {
+			t.Error("Client should have been removed after send error")
+		}
+	}
+}
+
+// TestGetOrCreateRoomEmptyID verifies empty room ID is rejected.
+func TestGetOrCreateRoomEmptyID(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	_, err := hotel.GetOrCreateRoom("")
+	if err == nil {
+		t.Error("Expected error for empty room ID")
+	}
+}
+
+// TestMultipleBroadcasts verifies multiple sequential broadcasts work correctly.
+func TestMultipleBroadcasts(t *testing.T) {
+	hotel := New(
+		func(ctx context.Context, id string) (*struct{}, error) {
+			return &struct{}{}, nil
+		},
+		func(ctx context.Context, room *Room[struct{}, struct{}, string]) {
+			<-ctx.Done()
+		},
+	)
+
+	room, err := hotel.GetOrCreateRoom("multi-broadcast")
+	if err != nil {
+		t.Fatalf("Failed to create room: %v", err)
+	}
+	defer room.Close()
+
+	client, err := room.NewClient(&struct{}{})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	var received atomic.Int32
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range client.Receive() {
+			received.Add(1)
+		}
+	}()
+
+	// Send multiple broadcasts
+	numMessages := 100
+	for i := 0; i < numMessages; i++ {
+		room.Broadcast("message")
+	}
+
+	// Give time to receive
+	time.Sleep(100 * time.Millisecond)
+	client.Close()
+	wg.Wait()
+
+	if int(received.Load()) != numMessages {
+		t.Errorf("Expected %d messages, got %d", numMessages, received.Load())
+	}
+}


### PR DESCRIPTION
This PR fixes three critical race condition bugs identified in the library:

1. **Metadata() data race**: Protected metadata field access with the existing mutex to ensure thread-safe concurrent access during initialization and reading.

2. **GetOrCreateRoom returning closed rooms**: Added a check after room retrieval to verify the room is still usable. If a room closes between retrieval and return, the code now retries to create a fresh room instead of returning a closed one.

3. **Client message loss on close**: Modified the client forwarding goroutine to drain all buffered messages before closing the send channel, ensuring queued messages are delivered even when the client is closed.

Added comprehensive test coverage for all three bugs with -race flag enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes races by locking room metadata, avoiding returning closed rooms via retry/cleanup, and draining client buffers on close; adds comprehensive tests.
> 
> - **Core concurrency fixes**:
>   - `hotel/hotel.go`: Reworks `GetOrCreateRoom` to retry on immediately-closed rooms, clean up map entries safely, and cap retries via `maxRoomAttempts`.
>   - `hotel/room.go`: Protects `room.metadata` with mutex on write and adds read lock in `Metadata()`.
>   - `hotel/client.go`: Ensures `sendCh` is closed once and drains `bufferCh` on context cancellation to deliver queued messages.
> - **Lifecycle/cleanup tweaks**:
>   - Room removal from `rooms` map now checks identity before delete to avoid races.
> - **Tests (broad coverage)**:
>   - Add race and behavior tests for room creation/closure (`race_test.go`), client lifecycle and buffering (`client_test.go`), room broadcasting and APIs (`room_test.go`), event type strings (`event_test.go`), and message registry (`messages_test.go`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53bcb857792ebb3a18ef61af830b09f2dc761aa2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->